### PR TITLE
Upgrade packages in Dockerfile

### DIFF
--- a/docker/Dockerfile.linux.amd64
+++ b/docker/Dockerfile.linux.amd64
@@ -1,4 +1,7 @@
 FROM nginx:stable-alpine
+
+RUN apt-get update && apt-get -y upgrade
+
 COPY dist /usr/share/nginx/html
 EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
The alpine version the latest nginx image was built from has a curl vuln. If we upgrade packages as part of our CI pipeline we can ensure we get the latest security upgrades regardless of upstream.