### PR TITLE
Fix Sentry alerts

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -5,6 +5,7 @@ const nextConfig = {
   experimental: {
     instrumentationHook: true,
   },
+  transpilePackages: ['chart.js'],
   rewrites: async () => {
     return [
       {

--- a/utils/currencyFormatter.ts
+++ b/utils/currencyFormatter.ts
@@ -6,5 +6,6 @@ export const currencyFormatter = new Intl.NumberFormat('en-GB', {
 export const currencyFormatterNoFraction = new Intl.NumberFormat('en-GB', {
   style: 'currency',
   currency: 'GBP',
+  minimumFractionDigits: 0,
   maximumFractionDigits: 0,
 })


### PR DESCRIPTION
Next.js supports Safari 12+ but Chart.js errors out on Safari 13 due to using unsupported syntax. We'll transpile the package to support that.
Fix `maximumFractionDigits value is out of range` error which occurred on Chrome Mobile WebView 107.0.5304